### PR TITLE
Use async httpx client for external requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ fastai<2.8.0
 fastapi-limiter==0.1.6
 redis==6.0.0
 nest-asyncio==1.6.0
+httpx==0.27.0

--- a/src/routes.py
+++ b/src/routes.py
@@ -30,7 +30,7 @@ async def upload_image(request: Annotated[ImageUploadRequest, Form()]):
 
 @app.post(f"{basepath}/extract-reading", response_model=ReadingExtractionResponse, response_model_exclude_none=True)
 async def extract_reading(request: ReadingExtractionRequest, background_tasks: BackgroundTasks):
-    response = flow_vision_service.extract_reading(request, background_tasks)
+    response = await flow_vision_service.extract_reading(request, background_tasks)
     return response
 
 

--- a/src/service/api/image_service.py
+++ b/src/service/api/image_service.py
@@ -15,7 +15,7 @@ from conf.config import Config
 from service.api.metadata_service import MetadataStore
 from PIL import Image, ImageOps
 
-import requests
+import httpx
 from io import BytesIO
 import numpy as np
 import cv2
@@ -90,8 +90,11 @@ class ImageService:
         cropped_image = image.crop((left, top, right, bottom))
         return cropped_image
 
-    def preprocess_image(self, imageURL):
-        image = Image.open(BytesIO(requests.get(imageURL).content))
+    async def preprocess_image(self, imageURL):
+        async with httpx.AsyncClient() as client:
+            response = await client.get(imageURL)
+            response.raise_for_status()
+            image = Image.open(BytesIO(response.content))
         image = ImageOps.exif_transpose(image)
         resized_image = self.resize_image(image, max_height=self.resizing_height, max_width=self.resizing_width)
         cropped_image = self.crop_image(resized_image)
@@ -100,7 +103,7 @@ class ImageService:
         # cropped_image.save("image_used.png")
         return image_buffer.getvalue()
 
-    def extract_reading(self, request: ReadingExtractionRequest, background_tasks: BackgroundTasks) -> ReadingExtractionResponse:
+    async def extract_reading(self, request: ReadingExtractionRequest, background_tasks: BackgroundTasks) -> ReadingExtractionResponse:
         status_code = HTTPStatus.OK.value
         response_code = ResponseCode.OK
         request.id = request.id if request.id else uuid4()
@@ -110,7 +113,7 @@ class ImageService:
         try:
             start_time = datetime.now()
             self.extraction_logger.info(str(request.model_dump_json()))
-            cropped_image = self.preprocess_image(request.imageURL)
+            cropped_image = await self.preprocess_image(request.imageURL)
 
             # Get quality status from BFM classification
             quality_result = classify_bfm_image(cropped_image)

--- a/src/service/api/storage_service.py
+++ b/src/service/api/storage_service.py
@@ -6,7 +6,7 @@ from conf.config import Config
 import logging
 from http import HTTPStatus
 from datetime import datetime
-import requests
+import httpx
 import boto3
 from botocore.config import Config as BotoConfig
 from uuid import uuid4, UUID
@@ -26,13 +26,14 @@ class StorageService:
     # endpoint_url=config.find("s3.endpoint_url"),
     )
 
-  def _send_to_storage(self, url, image_bytes, content_type):
+  async def _send_to_storage(self, url, image_bytes, content_type):
     try:
-      http_response = requests.put(
-        url=url,
-        data=image_bytes,
-        headers={'Content-Type': content_type}
-      )
+      async with httpx.AsyncClient() as client:
+        http_response = await client.put(
+          url,
+          content=image_bytes,
+          headers={'Content-Type': content_type}
+        )
     except Exception as e:
       self.logger.error(f"Error uploading image to presigned URL: {str(e)}")
       raise CustomHTTPException(
@@ -44,12 +45,13 @@ class StorageService:
       self.logger.error(f"AWS PUT BUCKET RESPONSE: {http_response.__dict__}")
       raise CustomHTTPException(
         status_code=http_response.status_code,
-        detail=f"Error uploading image to presigned URL: {http_response.reason}"
+        detail=f"Error uploading image to presigned URL: {http_response.reason_phrase}"
       )
 
   async def _get_from_storage(self, url):
     try:
-      http_response = requests.get(url=url)
+      async with httpx.AsyncClient() as client:
+        http_response = await client.get(url)
     except Exception as e:
       self.logger.error(f"Error retrieving image from presigned URL: {str(e)}")
       raise CustomHTTPException(
@@ -60,7 +62,7 @@ class StorageService:
       self.logger.error(f"AWS GET BUCKET RESPONSE: {http_response.__dict__}")
       raise CustomHTTPException(
         status_code=http_response.status_code,
-        detail=f"Error retrieving image from presigned URL: {http_response.reason}"
+        detail=f"Error retrieving image from presigned URL: {http_response.reason_phrase}"
       )
     return http_response.content
 
@@ -76,7 +78,7 @@ class StorageService:
       download_url = self.generate_presigned_download_url(object_key=file_name)
       self.logger.info(msg=f"PRESIGNED DOWNLOAD URL GENERATED: {download_url}")
 
-      self._send_to_storage(url=upload_url, image_bytes=image_bytes, content_type=content_type)
+      await self._send_to_storage(url=upload_url, image_bytes=image_bytes, content_type=content_type)
       await request.image.close()
 
       result = ImageUploadResult(imageURL=download_url)


### PR DESCRIPTION
## Summary
- switch image preprocessing to use `httpx.AsyncClient`
- replace storage service requests with async httpx and await calls
- add `httpx` dependency

## Testing
- `pytest`
- `python -m py_compile src/service/api/image_service.py src/service/api/storage_service.py src/routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae97e730b48320af327ddb0813098d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Migrated image processing and storage operations to asynchronous execution, improving responsiveness and throughput during reading extraction and image uploads.
  - Enhanced error handling for remote requests to provide more reliable feedback on failures.

- Chores
  - Updated dependencies to support async networking.

- User Impact
  - Faster, more reliable image uploads and reading extraction, especially under load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->